### PR TITLE
force GetTotalCount return value to be 64-bit int

### DIFF
--- a/WiredTigerNet/NativeTiger.cpp
+++ b/WiredTigerNet/NativeTiger.cpp
@@ -6,7 +6,7 @@ inline int min(int a, int b) {
 }
 
 NativeCursor::NativeCursor(WT_CURSOR* cursor) :
-	cursor_(cursor), 
+	cursor_(cursor),
 	boundary_(nullptr),
 	keyIsString_(strcmp(cursor_->key_format, "S") == 0) {
 }
@@ -122,8 +122,8 @@ NativeCursor::~NativeCursor() {
 	}
 }
 
-long NativeCursor::GetTotalCount(Byte* left, int leftSize, bool leftInclusive, Byte* right, int rightSize, bool rightInclusive) {
-	long result = 0;
+__int64 NativeCursor::GetTotalCount(Byte* left, int leftSize, bool leftInclusive, Byte* right, int rightSize, bool rightInclusive) {
+	__int64 result = 0;
 	if (IterationBegin(left, leftSize, leftInclusive, right, rightSize, rightInclusive, Ascending, false))
 		do
 		{

--- a/WiredTigerNet/NativeTiger.h
+++ b/WiredTigerNet/NativeTiger.h
@@ -25,7 +25,7 @@ public:
 	~NativeCursor();
 	bool IterationBegin(Byte* left, int leftSize, bool leftInclusive, Byte* right, int rightSize, bool rightInclusive, NativeDirection newDirection, bool copyBoundary);
 	bool IterationMove();
-	long GetTotalCount(Byte* left, int leftSize, bool leftInclusive, Byte* right, int rightSize, bool rightInclusive);
+	__int64 GetTotalCount(Byte* left, int leftSize, bool leftInclusive, Byte* right, int rightSize, bool rightInclusive);
 	int Reset();
 	const char* KeyFormat() const { return cursor_->key_format; }
 	const char* ValueFormat() const { return cursor_->value_format; }

--- a/WiredTigerNet/WiredTigerNet.cpp
+++ b/WiredTigerNet/WiredTigerNet.cpp
@@ -360,7 +360,7 @@ bool Cursor::SearchNear(array<Byte>^ key, [System::Runtime::InteropServices::Out
 	})
 }
 
-long Cursor::GetTotalCount(Range range) {
+__int64 Cursor::GetTotalCount(Range range) {
 	RANGE_UNWRAP()
 
 	INVOKE_NATIVE(return cursor_->GetTotalCount(leftPtr, leftSize, range.Left.HasValue && range.Left.Value.Inclusive,

--- a/WiredTigerNet/WiredTigerNet.h
+++ b/WiredTigerNet/WiredTigerNet.h
@@ -137,7 +137,7 @@ namespace WiredTigerNet {
 		void Reset();
 		bool Search(array<Byte>^ key);
 		bool SearchNear(array<Byte>^ key, [System::Runtime::InteropServices::OutAttribute] int% result);
-		long GetTotalCount(Range range);
+		__int64 GetTotalCount(Range range);
 		array<Byte>^ GetKey();
 		array<Byte>^ GetValue();
 		bool IterationBegin(Range range, Direction direction);


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/0wf2yk2k.aspx, long is 32-bit integer in C++ CLI, this PR fixes GetTotalCount() method to return 64-bit integer value.